### PR TITLE
add processing uncle-objects

### DIFF
--- a/src/repositories/eth/uncleCidsRepository.ts
+++ b/src/repositories/eth/uncleCidsRepository.ts
@@ -1,0 +1,24 @@
+import {DeepPartial, EntityRepository, Repository} from 'typeorm';
+import UncleCids from '../../models/eth/uncleCids';
+import {EthUncleCid} from "../../types";
+
+@EntityRepository(UncleCids)
+export default class UncleCidsRepository extends Repository<UncleCids> {
+
+	public async add(headerId: number, uncle: EthUncleCid): Promise<UncleCids> {
+		const result = await this.createQueryBuilder()
+			.insert()
+			.values({
+				headerId: headerId,
+				blockHash: uncle.blockHash,
+				parentHash: uncle.parentHash,
+				cid: uncle.cid,
+				mhKey: uncle.mhKey,
+				reward: uncle.mhKey,
+			})
+			.returning("*")
+			.execute();
+		return this.create(result.generatedMaps[0] as DeepPartial<UncleCids>)
+	}
+
+}

--- a/src/repositories/graphqlRepository.ts
+++ b/src/repositories/graphqlRepository.ts
@@ -240,61 +240,74 @@ export default class GraphqlRepository {
 			subscription SubscriptionHeader {
 				listen(topic: "header_cids") {
 					relatedNode {
-					... on EthHeaderCid {
-						id
-						td
-						blockHash
-						blockNumber
-						blockByMhKey {
-							data
-						}
-						bloom
-						cid
-						mhKey
-						nodeId
-						ethNodeId
-						parentHash
-						receiptRoot
-						reward
-						timesValidated
-						timestamp
-						txRoot
-						uncleRoot
-						stateRoot
-						ethTransactionCidsByHeaderId {
-						  nodes {
+						... on EthHeaderCid {
 							id
+							td
+							blockHash
+							blockNumber
+							blockByMhKey {
+								data
+							}
+							bloom
 							cid
-							headerId
-							index
 							mhKey
 							nodeId
-							dst
-							src
-							txData
-							txHash
-							blockByMhKey {
-							  data
-							}
-							receiptCidByTxId {
-								blockByMhKey {
-									data
+							ethNodeId
+							parentHash
+							receiptRoot
+							reward
+							timesValidated
+							timestamp
+							txRoot
+							uncleRoot
+							stateRoot
+							ethTransactionCidsByHeaderId {
+								nodes {
+									id
+									cid
+									headerId
+									index
+									mhKey
+									nodeId
+									dst
+									src
+									txData
+									txHash
+									blockByMhKey {
+										data
+									}
+									receiptCidByTxId {
+										blockByMhKey {
+											data
+										}
+										postStatus
+										cid
+										contract
+										contractHash
+										topic0S
+										topic1S
+										topic2S
+										topic3S
+										postState
+										logContracts
+										mhKey
+									}
 								}
-								postStatus
-								cid
-								contract
-								contractHash
-								topic0S
-								topic1S
-								topic2S
-								topic3S
-								postState
-								logContracts
-								mhKey
 							}
-						  }
+							uncleCidsByHeaderId {
+								nodes {
+									blockByMhKey {
+										data
+										key
+									}
+									blockHash
+									parentHash
+									cid
+									mhKey
+									reward
+								}
+							}
 						}
-					}
 					}
 				}
 			}

--- a/src/run.ts
+++ b/src/run.ts
@@ -23,6 +23,11 @@ process.on('unhandledRejection', (reason, p) => {
 		},
 		processHeader: async (data) => {
 			const header: HeaderCids = await dataService.processHeader(data);
+			if (data?.uncleCidsByHeaderId?.nodes && data?.uncleCidsByHeaderId?.nodes.length > 0) {
+				for (const uncle of data?.uncleCidsByHeaderId?.nodes) {
+					await dataService.processUncle(uncle, header.id);
+				}
+			}
 			if (data?.ethTransactionCidsByHeaderId?.nodes && data?.ethTransactionCidsByHeaderId?.nodes.length > 0) {
 				const txs = data.ethTransactionCidsByHeaderId.nodes;
 				for (const tx of txs) {

--- a/src/services/dataService.ts
+++ b/src/services/dataService.ts
@@ -10,10 +10,12 @@ import Contract from '../models/contract/contract';
 import ProgressRepository from '../repositories/data/progressRepository';
 import GraphqlService from './graphqlService';
 import HeaderCids from '../models/eth/headerCids';
+import UncleCids from '../models/eth/uncleCids';
 import TransactionCids from '../models/eth/transactionCids';
 import TransactionCidsRepository from '../repositories/eth/transactionCidsRepository';
 import ReceiptCidsRepository from '../repositories/eth/receiptCidsRepository';
 import HeaderCidsRepository from '../repositories/eth/headerCidsRepository';
+import UncleCidsRepository from '../repositories/eth/uncleCidsRepository';
 import StateCids from '../models/eth/stateCids';
 import State from '../models/contract/state';
 import ApplicationError from '../errors/applicationError';
@@ -29,6 +31,7 @@ import {
 	ABI,
 	ABIElem,
 	ABIInput, ABIInputData,
+	EthUncleCid,
 	EthHeaderCid,
 	EthReceiptCid,
 	EthStateCid,
@@ -329,6 +332,20 @@ VALUES
 
 			return header;
 		});
+	}
+
+	public async processUncle(rawUncle: EthUncleCid, headerId: number): Promise<UncleCids> {
+		if (!rawUncle) {
+			return null;
+		}
+
+		return getConnection().transaction(async (entityManager) => {
+			const uncleCidsRepository: UncleCidsRepository = entityManager.getCustomRepository(UncleCidsRepository);
+			const blockRepository: BlockRepository = entityManager.getCustomRepository(BlockRepository);
+
+			await blockRepository.add(rawUncle.mhKey, rawUncle.blockByMhKey.key)
+			return uncleCidsRepository.add(headerId, rawUncle);
+		})
 	}
 
 	// TODO: add decoded values

--- a/src/types/graphql.ts
+++ b/src/types/graphql.ts
@@ -33,6 +33,19 @@ export type ethTransactionCids = {
     nodes: EthTransactionCid[];
 }
 
+export type EthUncleCid = {
+    blockByMhKey: BlockByMhKey;
+    blockHash: string;
+    parentHash: string;
+    cid: string;
+    mhKey: string;
+    reward: string;
+}
+
+export type ethUncleCids = {
+    nodes: EthUncleCid[];
+}
+
 export type EthHeaderCid = {
     td: string;
     cid: string;
@@ -50,6 +63,7 @@ export type EthHeaderCid = {
     timesValidated: number;
     timestamp: string;
     ethTransactionCidsByHeaderId: ethTransactionCids;
+    uncleCidsByHeaderId: ethUncleCids;
 }
 
 export type EthStateCid = {
@@ -69,7 +83,6 @@ export type EthStorageCid = {
     blockByMhKey: BlockByMhKey;
     storageLeafKey: string;
     storagePath: string;
-
 };
 
 export type BlockByMhKey = {


### PR DESCRIPTION
This PR contains processing Uncles in `eth-watcher-ts` when `HEADER_WATCHER` is enabled. It is required to properly calculate block size in block-explorer.